### PR TITLE
fix: Change name of instance id header

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -54,7 +54,7 @@ where
             unleash_app_name_header: C::build_header("unleash-appname")?,
             unleash_sdk_header: C::build_header("unleash-sdk")?,
             unleash_connection_id_header: C::build_header("unleash-connection-id")?,
-            instance_id_header: C::build_header("instance_id")?,
+            instance_id_header: C::build_header("unleash-instanceid")?,
         })
     }
 


### PR DESCRIPTION
## About the changes
While using `unleash-rust-sdk` with GitLab feature flags, I was receiving this error: `Error: Failed to register with unleash API server`. I did not have issues while using other clients (e.g. [Node](https://docs.getunleash.io/reference/sdks/node)). I was able to successfully use the client after changing the name of the Instance ID header.

## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
I'm a bit unfamiliar with this ecosystem (I had not used Unleash or GitLab feature flags prior to today), so looking for some feedback as well on if this is a proper fix or not!
