### PR TITLE
Update Cargo package version to 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unleash-api-client"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Robert Collins <robert.collins@cognite.com>"]
 edition = "2021"
 rust-version = "1.74"

--- a/src/http.rs
+++ b/src/http.rs
@@ -198,7 +198,7 @@ mod tests {
         let headers = &http_client.client.headers.read().unwrap();
 
         assert_eq!(headers.get("unleash-appname").unwrap(), "my_app");
-        assert_eq!(headers.get("instance_id").unwrap(), "my_instance_id");
+        assert_eq!(headers.get("unleash-instanceid").unwrap(), "my_instance_id");
         assert_eq!(
             headers.get("unleash-connection-id").unwrap(),
             "d512f8ec-d972-40a5-9a30-a0a6e85d93ac"

--- a/src/http.rs
+++ b/src/http.rs
@@ -54,7 +54,7 @@ where
             unleash_app_name_header: C::build_header("unleash-appname")?,
             unleash_sdk_header: C::build_header("unleash-sdk")?,
             unleash_connection_id_header: C::build_header("unleash-connection-id")?,
-            instance_id_header: C::build_header("instance_id")?,
+            instance_id_header: C::build_header("unleash-instanceid")?,
         })
     }
 


### PR DESCRIPTION
## About the changes
Update the Cargo package version to 0.15 so that the Cargo publish action detects a change.